### PR TITLE
Fix build error on compile

### DIFF
--- a/SoloThreadGrab/SoloThreadGrab.csproj
+++ b/SoloThreadGrab/SoloThreadGrab.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>C:\Users\Vaughn\Desktop\STG\</OutputPath>
+    <OutputPath>../dist/</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
The build path of the executable was an absolute path which resulted in a build error in VS 2019. This pull request fixes that error by specifying a relative build directory in the repository folder.